### PR TITLE
Fixes #51 : Particles Overlapping Image

### DIFF
--- a/resources/sass/home.scss
+++ b/resources/sass/home.scss
@@ -106,6 +106,7 @@ body {
     }
 
     &.section-cam-bg::before {
+        z-index: 2;
         background-image: url(https://miro.medium.com/max/12000/1*1SnGVpXWAyOyMpjbsJrPDA.jpeg);
         background-repeat: no-repeat;
         background-position: center center;


### PR DESCRIPTION
Set z-index for section-cam-bg::before to 2 to superimpose on particle.js canvas.