### PR TITLE
Add terms and conditions to site

### DIFF
--- a/app/Http/Controllers/Home.php
+++ b/app/Http/Controllers/Home.php
@@ -27,6 +27,10 @@ class Home extends Controller
         return view('frontpages/privacy');
     }
 
+    public function terms() {
+        return view('frontpages/terms');
+    }
+
  	// public function about() {
 	// 	return view('about');
 	// }

--- a/resources/views/frontpages/terms.blade.php
+++ b/resources/views/frontpages/terms.blade.php
@@ -1,0 +1,218 @@
+@extends('layouts.home')
+@section('title', 'Terms and Conditions — Hack Cambridge 101')
+
+@section('header-content')
+    <div id="intro-container">
+        <img id="top-logo-solo" src="{{ asset('images/101-white.png') }}" />
+    </div>
+@endsection
+
+@section('content')
+    <section id="" class="section-diagonal static-section">
+        <div class="container grid-lg" style="padding:2rem 30px 0.25rem;">
+            <h1 class="section-header">Terms and Conditions</h1>
+              <p class="body-text">
+                Hack Cambridge 101 is an event taking place from 18th January
+                2020 to the 19th January 2020 in Cambridge, UK. It will henceforth
+                be referred to as ‘the Event’ or ‘Hack Cambridge’.
+              </p>
+              <p class="body-text">
+                The Organisers of Hack Cambridge, henceforth referred to as
+                ‘the Organisers’ in this T&C, refer to any or all of the
+                individuals involved with organising the Event in any capacity.
+              </p class="body-text">
+                The Premises of Hack Cambridge, henceforth referred to as ‘the
+                Premises’ refer to the locations at which the Event is held.
+                These include, but are not necessarily limited to, the entire
+                building of the Cambridge Corn Exchange and Guildhall.
+              <p class="body-text">
+                ‘Terms and Conditions’ or ‘Agreement’ will refer to these Terms
+                and Conditions, including all of their provisions.
+              </p>
+        </div>
+      </section>
+
+      <section id="" class="section-diagonal">
+        <div class="container grid-lg" style="padding:2rem 30px 0rem;height:5px;">
+        </div>
+      </section>
+
+      <section id="" class="section-diagonal static-section">
+          <div class="container grid-lg" style="padding:0.5rem 30px 0.25rem;">
+              <h3 class="title-text">Admittance</h3>
+              <p class="body-text">
+                Your registration and RSVP entitles you to admittance to Hack Cambridge.
+                Any and all other costs associated with your attendance (including without
+                limitation travel and accommodation expenses) shall be borne solely by you,
+                and Hack Cambridge shall have no liability for such costs. Any travel or
+                hardware reimbursements will be given based on the sole discretion of the
+                Organisers of Hack Cambridge.
+              </p>
+              <h3 class="title-text">Age Requirements</h4>
+              <p class="body-text">
+                No one under the age of 18 will be admitted.
+              </p>
+              <h3 class="title-text">Intellectual Property </h3>
+                <p class="body-text">
+                  Attendees and participants own any intellectual property they produce at
+                  the Event and no sponsors or Organisers will make a claim to Intellectual
+                  Property rights of their products or creations.
+                </p>
+              <h3 class="title-text"> Use of Likeness </h3>
+              <p class="body-text">
+                By attending Hack Cambridge you acknowledge and agree to grant the Organisers
+                the right at Hack Cambridge to record, film, photograph, or capture your likeness
+                in any media now available or hereafter developed and to distribute, broadcast,
+                use, or otherwise globally to disseminate, in perpetuity, such media without
+                any further approval from you or any payment to you. This grant to the Organisers
+                includes, but is not limited to, the right to edit such media, the right to
+                use the media alone or together with other information, and the right to
+                allow others to use or disseminate the media.
+              </p>
+              <h3 class="title-text"> Event Content </h3>
+              <p class="body-text">
+                You acknowledge and agree that the Organisers, in their sole discretion,
+                reserves the right to change any and all aspects of the Event, including
+                but not limited to, the Event name, themes, content, programme, speakers,
+                performers, hosts, moderators, venue, and time.
+              </p>
+              <h3 class="title-text"> Wristband Usage </h3>
+              <p class="body-text">
+                Attendees’ identifying wristbands must be worn at all times in Event areas.
+                Failure to do so may result in difficulty in entering or re-entering the
+                Premises, or refusal by security staff to allow the attendee to enter or
+                re-enter the Premises. It may also result in expulsion from the Premises
+                by security.
+              </p>
+              <h3 class="title-text"> Disruptive or Unethical Conduct </h3>
+              <p class="body-text">
+                You acknowledge and agree that the Organisers and other security personnel,
+                volunteers at the Event, or staff of Cambridge Live reserve the right to
+                remove you from the Event if the Organisers, in their sole discretion,
+                determine that your presence or behavior create a disruption or hinder the
+                Event or the enjoyment of the Event by other attendees or to be of an
+                unethical or harrassing nature. All wristbands or distributed items
+                (including swag from sponsors) must then be returned to the Organisers
+                upon request. You also agree to abide by our Code of Conduct.
+              </p>
+              <a href='{{route('conduct')}}' target='_blank')> Read the Code of Conduct </a>
+        </div>
+      </section>
+
+      <section id="" class="section-diagonal">
+        <div class="container grid-lg" style="padding:2rem 30px 0rem;height:5px;">
+        </div>
+      </section>
+
+      <section id="" class="section-diagonal static-section">
+          <div class="container grid-lg" style="padding:2rem 30px 0.25rem;">
+
+              <p class="body-text">
+                Except as required by law, the Organisers of Hack Cambridge, or the venue
+                owners Cambridge Live trust, will not be held liable for any property loss
+                or damage, personal injury or death, or any economic loss, howsoever caused,
+                including by the negligence of the Organisers or Cambridge Live. These aforementioned
+                losses or damages or injuries or deaths include those arising directly or indirectly
+                from the Event or any other aspect related thereto or in connection with the Event
+                or this Agreement.
+              </p>
+              <p class="body-text">
+                The Organisers or Cambridge Live will not be held liable for any property
+                damage or loss, personal injury or death arising from the behaviour or
+                actions of any attendees of the Event. Attendees can include, but are not
+                limited to volunteers, representatives from any companies, mentors, judges,
+                room hosts or the Organisers themselves. This includes behaviour or actions
+                before, during, after the Event, or are in any way connected to the Event.
+              </p>
+              <p class="body-text">
+                The Organisers give no warranties in respect of any aspect of the Event or
+                any materials related thereto or offered at the Event and, to the fullest
+                extent possible under the laws governing this Agreement, disclaims all
+                implied warranties, including but not limited to warranties of fitness
+                for a particular purpose, accuracy, timeliness, and merchantability.
+                The Event is provided on an ‘as-is’ basis. The Organisers do not accept
+                any responsibility or liability for reliance by you or any person on any
+                aspect of the Event or any information provided at the Event.
+              </p>
+              <p class="body-text">
+                Each attendee must take reasonable steps to ensure their own safety
+                and the safety of others, as well as take reasonable care of the property
+                of theirselves and others. This especially applies to circumstances where
+                they are tired, when they are working with hardware and potentially dangerous
+                equipment, as well as when they are consuming any food or drink. They will
+                check that the food or drink complies with their dietary requirements, if
+                any.
+              </p>
+
+        </section>
+      </div>
+
+      <section id="" class="section-diagonal">
+        <div class="container grid-lg" style="padding:2rem 30px 0rem;height:5px;">
+        </div>
+      </section>
+
+      <section id="" class="section-diagonal static-section">
+          <div class="container grid-lg" style="padding:0.5rem 30px 0.25rem;">
+
+            <h2 class="title-text"> Reimbursements </h2>
+              <p class="body-text">
+                Do note that accommodation reimbursements will be prioritised beneath
+                travel reimbursements and therefore should not be depended upon.
+                They will also both be part of the total reimbursements cap we are
+                aiming to provide. Note that none of this constitutes a guarantee of
+                reimbursement&mdash;whether we reimburse and how much is solely at our
+                discretion.
+              </p>
+              <p class="body-text">
+                The Organisers of Hack Cambridge give no warranties or legal guarantees
+                in respect of any aspect of the travel or accommodation reimbursements
+                offered and, to the fullest extent possible under applicable laws,
+                disclaims all implied warranties.
+              </p>
+              <p class="body-text">
+                The Organisers of Hack Cambridge will not accept any responsibility or
+                liability for reliance by you or any person on any aspect of the
+                aforementioned reimbursements or any related information provided.
+                We reserve sole discretion to reimburse or refuse to reimburse any expenses.
+              </p>
+
+          </div>
+      </section>
+
+      <section id="" class="section-diagonal">
+        <div class="container grid-lg" style="padding:2rem 30px 0rem;height:5px;">
+        </div>
+      </section>
+
+      <section id="" class="section-diagonal static-section">
+          <div class="container grid-lg" style="padding:2rem 30px 0.25rem;">
+              <p class="body-text">
+                Neither party shall be liable to the other for any failure to perform any
+                obligation under the common law or under any Agreement which is due to
+                an event beyond the control of such party including but not limited to
+                any Act of God, terrorism, war, Political insurgence, insurrection, riot,
+                civil unrest, act of civil or military authority, uprising, earthquake,
+                flood or any other natural or man made eventuality outside of our control,
+                which causes the property damage or loss or death or injury any parties,
+                or termination of an agreement or contract entered into. Any party affected
+                by such event shall forthwith inform the other party of the same and shall
+                use all reasonable endeavors to comply with the terms and conditions of any
+                Agreement contained herein.
+              </p>
+              <p class="body-text">
+                The Organisers’ failure to exercise any right provided for herein shall not
+                be deemed a waiver of any further rights hereunder. The Organisers shall
+                not be liable for any failure to perform their obligations hereunder where
+                such failure results from any cause beyond the Organisers’ reasonable control.
+                If any provision of these Terms and Conditions is found to be unenforceable
+                or invalid, that provision shall be limited or eliminated to the minimum
+                extent necessary so that these Terms and Conditions shall otherwise remain
+                in full force and effect and enforceable. No agency, partnership, joint
+                venture, or employment is created as a result of these Terms and Conditions
+                and you acknowledge that you do not have any authority of any kind to bind
+                the Organisers or the Event or Cambridge Live in any respect whatsoever.
+              </p>
+        </div>
+    </section>
+@endsection

--- a/resources/views/layouts/home.blade.php
+++ b/resources/views/layouts/home.blade.php
@@ -65,6 +65,9 @@
                         <li class="breadcrumb-item">
                             <a href="{{route('privacy')}}">Privacy Policy</a>
                         </li>
+                        <li class="breadcrumb-item">
+                            <a href="{{route('terms')}}">Terms & Conditions</a>
+                        </li>
                     </ul>
                     <p id="copyright">© Hack Cambridge 2016-2020. Hack Cambridge is UK registered charity #1177223.</p>
                 </div>
@@ -124,7 +127,7 @@
 
             setInterval(nextGradient, refreshCadence);
         </script>
-        
+
         <!-- Global site tag (gtag.js) - Google Analytics -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-153422761-1"></script>
         <script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,7 @@ Route::middleware(['auth.check_staging'])->group(function() {
     Route::get('/apply', 'Home@apply')->name('apply');
     Route::get('/conduct', 'Home@conduct')->name('conduct');
     Route::get('/privacy', 'Home@privacy')->name('privacy');
+    Route::get('/terms', 'Home@terms')->name('terms');
     // Route::get('/foundation', 'Foundation@index')->name('foundation_index');
 
     // Protected routes - login will be forced.


### PR DESCRIPTION
Add terms and conditions to site. Somewhat based on [last year's design](https://web.archive.org/web/20190421232137/https://hackcambridge.com/terms-and-conditions). Not too happy on the division method, but we may need hackers to accept this on the form. Thoughts?

![Screenshot 2019-11-27 at 00 52 21](https://user-images.githubusercontent.com/13217875/69684391-6ac7f800-10b0-11ea-9c84-7533bbab74c8.png)
