### PR TITLE
Add reviewing capability option to sponsors

### DIFF
--- a/app/Http/Controllers/Committee.php
+++ b/app/Http/Controllers/Committee.php
@@ -80,7 +80,7 @@ class Committee extends Controller
     }
 
     private function initSession() {
-        if(Auth::check() && in_array(Auth::user()->type, ["committee", "admin"])) {
+        if(Auth::check() && in_array(Auth::user()->type, ["committee", "admin", "sponsor-reviewer"])) {
             return response()->json([
                 "success" => true,
                 "payload" => array(
@@ -99,7 +99,8 @@ class Committee extends Controller
     }
 
     private function canContinue($r, $stringChecks = [], $admin_only = true) {
-        $allowed = $admin_only ? ["admin"] : ["admin", "committee"];
+        $allowed = $admin_only ? ["admin"] : ["admin", "committee", "sponsor-reviewer"];
+        error_log(Auth::user(), 3, "/tmp/my-errors.log");
         if(Auth::check() && in_array(Auth::user()->type, $allowed)) {
             if($r) {
                 foreach ($stringChecks as $param) {

--- a/app/Http/Controllers/Committee.php
+++ b/app/Http/Controllers/Committee.php
@@ -100,7 +100,6 @@ class Committee extends Controller
 
     private function canContinue($r, $stringChecks = [], $admin_only = true) {
         $allowed = $admin_only ? ["admin"] : ["admin", "committee", "sponsor-reviewer"];
-        error_log(Auth::user(), 3, "/tmp/my-errors.log");
         if(Auth::check() && in_array(Auth::user()->type, $allowed)) {
             if($r) {
                 foreach ($stringChecks as $param) {
@@ -121,8 +120,7 @@ class Committee extends Controller
             ->select('applications.id', 'applications.isSubmitted', 'applications.user_id')
             ->join('users', 'users.id', '=', 'applications.user_id')
             ->select('applications.id', 'applications.isSubmitted')
-            ->where('users.type', '=', 'hacker')
-            ->where('applications.isSubmitted', "=", 1);
+            ->where('users.type', '=', 'hacker');
     }
 
     private function getAdminOverview() {
@@ -155,8 +153,14 @@ class Committee extends Controller
                 "overview" => array(
                     "users" => DB::table('users')->where('users.type', '=', 'hacker')->count(),
                     "applications" => array(
-                        "total" => $this->overviewBaseQuery()->count(),
-                        "invited" => $this->overviewBaseQuery()->where("invited", "=", 1)->count(),
+                        "total" => $this->overviewBaseQuery()
+                            ->count(),
+                        "submitted" => $this->overviewBaseQuery()
+                            ->where('isSubmitted', "=", 1)
+                            ->count(),
+                        "invited" => $this->overviewBaseQuery()
+                            ->where("invited", "=", 1)
+                            ->count(),
                         "invitations_pending" => $this->overviewBaseQuery()
                             ->where("invited", "=", 1)
                             ->where("rejected", "=", 0)

--- a/app/Http/Controllers/Dashboard.php
+++ b/app/Http/Controllers/Dashboard.php
@@ -28,7 +28,7 @@ class Dashboard extends Controller
             $application = Application::where("user_id", "=", Auth::user()->id)->first();
             if($application) {
                 $is_attendee = $application->confirmed && !$application->rejected;
-                if($is_attendee || in_array(Auth::user()->type, ["admin", "committee", "sponsor", "sponsor-reviewer")) {
+                if($is_attendee || in_array(Auth::user()->type, ["admin", "committee", "sponsor", "sponsor-reviewer"])) {
                     return redirect(self::$slack_invite_url);
                 }
             }

--- a/app/Http/Controllers/Dashboard.php
+++ b/app/Http/Controllers/Dashboard.php
@@ -28,7 +28,7 @@ class Dashboard extends Controller
             $application = Application::where("user_id", "=", Auth::user()->id)->first();
             if($application) {
                 $is_attendee = $application->confirmed && !$application->rejected;
-                if($is_attendee || in_array(Auth::user()->type, ["admin", "committee", "sponsor"])) {
+                if($is_attendee || in_array(Auth::user()->type, ["admin", "committee", "sponsor", "sponsor-reviewer")) {
                     return redirect(self::$slack_invite_url);
                 }
             }
@@ -142,7 +142,7 @@ class Dashboard extends Controller
 
     private function getOverviewStats() {
         if(Auth::check()) {
-            $allowed = in_array(Auth::user()->type, ["admin", "committee", "sponsor"]);
+            $allowed = in_array(Auth::user()->type, ["admin", "committee", "sponsor", "sponsor-reviewer"]);
             if(!$allowed) {
                 $application = Application::where("user_id", "=", Auth::user()->id)->first();
                 $allowed = $application && $application->confirmed && !$application->rejected;

--- a/app/Http/Controllers/Sponsors.php
+++ b/app/Http/Controllers/Sponsors.php
@@ -39,14 +39,14 @@ class Sponsors extends Controller
             case 'delete-sponsor': return $this->deleteSponsor($r);
             case 'update-sponsor': return $this->sponsorAdminDetailsUpdate($r);
             case 'load-agents-access': return $this->loadSponsorAgents($r, "access");
-            case 'load-agents-mentor': return $this->loadSponsorAgents($r, "mentor", ["sponsor", "admin"]);
-            case 'load-agents-recruiter': return $this->loadSponsorAgents($r, "recruiter", ["sponsor", "admin"]);
+            case 'load-agents-mentor': return $this->loadSponsorAgents($r, "mentor", ["sponsor", "sponsor-reviewer", "admin"]);
+            case 'load-agents-recruiter': return $this->loadSponsorAgents($r, "recruiter", ["sponsor", "sponsor-reviewer", "admin"]);
             case 'add-agent-access': return $this->addSponsorAgent($r, "access");
-            case 'add-agent-mentor': return $this->addSponsorAgent($r, "mentor", ["sponsor", "admin"]);
-            case 'add-agent-recruiter': return $this->addSponsorAgent($r, "recruiter", ["sponsor", "admin"]);
+            case 'add-agent-mentor': return $this->addSponsorAgent($r, "mentor", ["sponsor", "sponsor-reviewer", "admin"]);
+            case 'add-agent-recruiter': return $this->addSponsorAgent($r, "recruiter", ["sponsor", "sponsor-reviewer", "admin"]);
             case 'remove-agent-access': return $this->removeSponsorAgent($r, "access");
-            case 'remove-agent-mentor': return $this->removeSponsorAgent($r, "mentor", ["sponsor", "admin"]);
-            case 'remove-agent-recruiter': return $this->removeSponsorAgent($r, "recruiter", ["sponsor", "admin"]);
+            case 'remove-agent-mentor': return $this->removeSponsorAgent($r, "mentor", ["sponsor", "sponsor-reviewer", "admin"]);
+            case 'remove-agent-recruiter': return $this->removeSponsorAgent($r, "recruiter", ["sponsor", "sponsor-reviewer", "admin"]);
             case 'add-resource': return $this->addResource($r);
             case 'load-resources': return $this->loadResources($r);
             case 'delete-resource': return $this->deleteResource($r);
@@ -104,7 +104,7 @@ class Sponsors extends Controller
                               ->where("type", "agent")
                               ->where("email", Auth::user()->email)
                               ->get();
-            if($agent && Auth::user()->type == "sponsor") {
+            if($agent && (Auth::user()->type == "sponsor" || Auth::user()->type == "sponsor-reviewer")) {
                 return true;
             }
         }
@@ -153,7 +153,7 @@ class Sponsors extends Controller
     }
 
     public function storeAsset(Request $r) {
-        if($this->canContinue(["admin", "sponsor"], $r->request, ["sponsor_slug"])) {
+        if($this->canContinue(["admin", "sponsor-reviewer", "sponsor"], $r->request, ["sponsor_slug"])) {
             $sponsor_slug = $r->request->get("sponsor_slug");
             if ($r->hasFile('asset')) {
                 $directory = "sponsors/" . $sponsor_slug;
@@ -171,7 +171,7 @@ class Sponsors extends Controller
     }
 
     public function removeAsset(Request $r) {
-        if($this->canContinue(["admin", "sponsor"], $r->request, ["sponsor_slug", "asset_url"])) {
+        if($this->canContinue(["admin", "sponsor-reviewer", "sponsor"], $r->request, ["sponsor_slug", "asset_url"])) {
             $sponsor_slug = $r->request->get("sponsor_slug");
             $url =  $r->request->get("asset_url");
 
@@ -409,7 +409,7 @@ class Sponsors extends Controller
     }
 
     private function addResource($r) {
-        if($this->canContinue(["admin", "sponsor"], $r, ["sponsor_id", "sponsor_slug", "payload", "detail_id", "detail_type", "complete"])) {
+        if($this->canContinue(["admin", "sponsor-reviewer", "sponsor"], $r, ["sponsor_id", "sponsor_slug", "payload", "detail_id", "detail_type", "complete"])) {
             $id = $r->get("sponsor_id");
             $slug = $r->get("sponsor_slug");
             $payload = $r->get("payload");
@@ -462,7 +462,7 @@ class Sponsors extends Controller
     }
 
     private function loadResources($r) {
-        if($this->canContinue(["admin", "committee", "sponsor"], $r, ["sponsor_id", "sponsor_slug"])) {
+        if($this->canContinue(["admin", "committee", "sponsor-reviewer", "sponsor"], $r, ["sponsor_id", "sponsor_slug"])) {
             $id = $r->get("sponsor_id");
             $slug = $r->get("sponsor_slug");
             $detail_type = $r->get("detail_type");
@@ -495,7 +495,7 @@ class Sponsors extends Controller
     }
 
     private function deleteResource($r) {
-        if($this->canContinue(["admin", "sponsor"], $r, ["sponsor_id", "sponsor_slug", "detail_id", "detail_type"])) {
+        if($this->canContinue(["admin", "sponsor-reviewer", "sponsor"], $r, ["sponsor_id", "sponsor_slug", "detail_id", "detail_type"])) {
             $detail_id = $r->get("detail_id");
             $id = $r->get("sponsor_id");
             $slug = $r->get("sponsor_slug");

--- a/app/Http/Middleware/CheckType.php
+++ b/app/Http/Middleware/CheckType.php
@@ -9,9 +9,9 @@ class CheckType
 {
 
     private $allowed = array(
-        "hacker" => ["hacker", "sponsor", "committee", "admin"],
-        "sponsor" => ["sponsor", "committee", "admin"],
-        "committee" => ["committee", "admin"],
+        "hacker" => ["hacker", "sponsor", "sponsor-reviewer", "committee", "admin"],
+        "sponsor" => ["sponsor", "sponsor-reviewer", "committee", "admin"],
+        "committee" => ["committee", "admin", "sponsor-reviewer"],
         "admin" => ["admin"],
     );
 
@@ -41,6 +41,7 @@ class CheckType
         switch ($type) {
             case "hacker": return redirect(route('dashboard_index'));
             case "sponsor": return redirect(route('sponsors_dashboard'));
+            case "sponsor-reviewer": return redirect(route('sponsors_dashboard'));
             case "committee": return redirect(route('committee_dashboard'));
             default: return redirect(route('home'));
         }

--- a/app/Repositories/CustomUserRepository.php
+++ b/app/Repositories/CustomUserRepository.php
@@ -4,6 +4,7 @@ namespace App\Repositories;
 
 use App\User;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
 
 use Auth0\Login\Auth0User;
 use Auth0\Login\Auth0JWTUser;
@@ -37,6 +38,12 @@ class CustomUserRepository extends Auth0UserRepository {
             $user->setAttribute('profile', '{}');
         }
 
+        $privileges = DB::table("sponsor_agents")
+                ->where("email", "=", $user->email)
+                ->join("sponsors","sponsors.id","=","sponsor_agents.sponsor_id")->select("privileges")->first();
+        if ($user->type == "sponsors" && strpos($privileges,"reviewing")) {
+            $user->setAttribute('type', "sponsor-reviewer");
+        }
         $user->setAttribute('email', isset( $profile['email'] ) ? $profile['email'] : '');
         $user->setAttribute('name', isset( $profile['name'] ) ? $profile['name'] : '');
                 

--- a/app/Repositories/CustomUserRepository.php
+++ b/app/Repositories/CustomUserRepository.php
@@ -38,12 +38,17 @@ class CustomUserRepository extends Auth0UserRepository {
             $user->setAttribute('profile', '{}');
         }
 
-        $privileges = DB::table("sponsor_agents")
-                ->where("email", "=", $user->email)
-                ->join("sponsors","sponsors.id","=","sponsor_agents.sponsor_id")->select("privileges")->first();
-        if ($user->type == "sponsors" && strpos($privileges,"reviewing")) {
-            $user->setAttribute('type', "sponsor-reviewer");
+        if ($user->type == "sponsor" || $user->type == "sponsor-reviewer") {
+            $sponsor = DB::table("sponsor_agents")
+                    ->where("email", "=", $user->email)
+                    ->join("sponsors","sponsors.id","=","sponsor_agents.sponsor_id")->select("privileges")->first();
+            if (strpos($sponsor->privileges,"reviewing")) {
+                $user->setAttribute('type', "sponsor-reviewer");
+            } else {
+                $user->setAttribute('type', "sponsor");
+            }
         }
+        
         $user->setAttribute('email', isset( $profile['email'] ) ? $profile['email'] : '');
         $user->setAttribute('name', isset( $profile['name'] ) ? $profile['name'] : '');
                 

--- a/resources/js/components/committee/CommitteeDashboard.tsx
+++ b/resources/js/components/committee/CommitteeDashboard.tsx
@@ -141,7 +141,8 @@ class Dashboard extends Component<IDashboardPropsWithRouter, IDashboardState> {
                         {
                             url: `${this.props.baseUrl}/checkin`,
                             label: "Check-in",
-                            icon: ChecklistMajor
+                            icon: ChecklistMajor,
+                            disabled: this.props.user.type == "sponsor-reviewer"
                         },
                         {
                             onClick: this.startReviewing,

--- a/resources/js/components/committee/components/Overview.tsx
+++ b/resources/js/components/committee/components/Overview.tsx
@@ -46,10 +46,8 @@ class Overview extends Component<IAdminOverviewProps, IAdminOverviewState> {
                     <Card sectioned title={""}>
                         <Stack>
                             <Button monochrome outline>{`${overview.users}`} registrations</Button>
-                            <Button url={`applications`} monochrome outline>{`${overview.applications.total}`} applications</Button>
-                        </Stack>
-                        <br />
-                        <Stack>
+                            <Button monochrome outline>{`${overview.applications.total}`} applications</Button>
+                            <Button url={`applications`} monochrome outline>{`${overview.applications.submitted}`} submitted</Button>
                             <Button monochrome outline>{`${overview.applications.invited}`} invited</Button>
                             <Button monochrome outline>{`${overview.applications.invitations_pending}`} pending</Button>
                             <Button monochrome outline>{`${overview.applications.accepted}`} confirmed</Button>
@@ -100,7 +98,6 @@ class Overview extends Component<IAdminOverviewProps, IAdminOverviewState> {
                 }
             }
             toast.error("Failed to load data.");
-            // console.log(status, res.data);
             this.setState({ isLoading: false });
         });
     }

--- a/resources/js/components/dashboard/Dashboard.tsx
+++ b/resources/js/components/dashboard/Dashboard.tsx
@@ -8,10 +8,9 @@ import {
     Navigation,
     Banner,
 } from "@shopify/polaris";
-import { LogOutMinor, IqMajor, AddCodeMajor, CustomerPlusMajor, HomeMajor, ConfettiMajor, LocationMajor, FlagMajor, SocialAdMajor, QuestionMarkMajor } from '@shopify/polaris-icons';
+import { LogOutMinor, IqMajor, AddCodeMajor, CustomerPlusMajor, HomeMajor, ConfettiMajor, FlagMajor, SocialAdMajor, QuestionMarkMajor } from '@shopify/polaris-icons';
 import Dashboard404 from "./Dashboard404";
 import Overview from "./components/Overview";
-import MapView from "./components/MapView";
 import Apply from "./components/Apply";
 import TeamApplication from "./components/TeamApplication";
 import axios from 'axios';

--- a/resources/js/components/sponsors-dashboard/SponsorDashboard.tsx
+++ b/resources/js/components/sponsors-dashboard/SponsorDashboard.tsx
@@ -178,7 +178,7 @@ class SponsorDashboard extends Component<ISponsorDashboardAppendedProps, ISponso
             />
         );
 
-        if(isRoot && this.props.user.type == "sponsor" && this.props.sponsors.length > 0) {
+        if(isRoot && (this.props.user.type == "sponsor" || this.props.user.type == "sponsor-reviewer") && this.props.sponsors.length > 0) {
             return <Redirect to={`${this.props.sponsors[0].slug}/overview`} />;
         }
         else if(section.length == 0 && sponsor && this.props.validRoute) {

--- a/resources/js/components/sponsors-dashboard/components/SponsorAdmin.tsx
+++ b/resources/js/components/sponsors-dashboard/components/SponsorAdmin.tsx
@@ -1,13 +1,12 @@
-import React, { Component, useState, useCallback } from "react";
+import React, { Component } from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import { Page, ChoiceList, TextField, Layout, Card, RangeSlider, Avatar, ResourceList, TextStyle, Button, Icon } from "@shopify/polaris";
+import { Page, ChoiceList, TextField, Layout, Card, Avatar, ResourceList, TextStyle, Button } from "@shopify/polaris";
 import { AddMajor } from '@shopify/polaris-icons';
 import { ISponsorAgent, ISponsorData } from "../../../interfaces/sponsors.interfaces";
 import axios from "axios";
 import SponsorAgentForm from "./Agents/SponsorAgentForm";
 import DestructiveConfirmation from "./common/DestructiveConfirmation";
 import { toast } from "react-toastify";
-import { toAdminPath } from "@shopify/app-bridge/actions/Navigation/Redirect";
 
 interface ISponsorAdminProps extends RouteComponentProps {
     baseSponsorPath: string,

--- a/resources/js/components/sponsors-dashboard/components/SponsorAdmin.tsx
+++ b/resources/js/components/sponsors-dashboard/components/SponsorAdmin.tsx
@@ -71,6 +71,10 @@ class SponsorAdmin extends Component<ISponsorAdminProps, ISponsorAdminState> {
         {
             label: 'Can give opening ceremony presentation',
             value: 'presentation',
+        },
+        {
+            label: 'Can view and review hackers\' applications',
+            value: 'reviewing',
         }
     ];
 

--- a/resources/js/interfaces/committee.interfaces.tsx
+++ b/resources/js/interfaces/committee.interfaces.tsx
@@ -7,6 +7,7 @@ export interface IAdminOverview {
     users: number,
     applications: {
         total: number,
+        submitted: number,
         invited: number,
         invitations_pending: number,
         accepted: number,


### PR DESCRIPTION
This will be achieved by introducing a new role to the system called `sponsor-reviewer` which will have the same capabilities as a `sponsor` + the option to access the _Committee Dashboard_ for reviews.

The role will be dynamically given to all sponsors who have the _reviewing_ privilege and taken from any existing sponsors who no longer have it (in case of updates).